### PR TITLE
Throw bad requests when TaxCodeMismatch returns no data

### DIFF
--- a/app/uk/gov/hmrc/tai/controllers/taxCodeChange/TaxCodeChangeController.scala
+++ b/app/uk/gov/hmrc/tai/controllers/taxCodeChange/TaxCodeChangeController.scala
@@ -20,6 +20,7 @@ import com.google.inject.Inject
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent}
 import uk.gov.hmrc.domain.Nino
+import uk.gov.hmrc.http.BadRequestException
 import uk.gov.hmrc.play.bootstrap.controller.BaseController
 import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
 import uk.gov.hmrc.tai.config.FeatureTogglesConfig
@@ -58,6 +59,8 @@ class TaxCodeChangeController @Inject()(authentication: AuthenticationPredicate,
     implicit request =>
       taxCodeChangeService.taxCodeMismatch(nino).map { taxCodeMismatch =>
         Ok(Json.toJson(ApiResponse(taxCodeMismatch, Seq.empty)))
+      } recover {
+        case ex: BadRequestException => BadRequest(Json.toJson(Map("reason" → ex.getMessage)))
       }
   }
 }

--- a/app/uk/gov/hmrc/tai/service/TaxCodeChangeService.scala
+++ b/app/uk/gov/hmrc/tai/service/TaxCodeChangeService.scala
@@ -21,7 +21,7 @@ import org.joda.time.LocalDate
 import play.api.Logger
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import uk.gov.hmrc.domain.Nino
-import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.{BadRequestException, HeaderCarrier}
 import uk.gov.hmrc.tai.audit.Auditor
 import uk.gov.hmrc.tai.connectors.TaxCodeChangeConnector
 import uk.gov.hmrc.tai.model.{TaxCodeMismatch, TaxCodeRecord}
@@ -118,7 +118,7 @@ class TaxCodeChangeServiceImpl @Inject()(taxCodeChangeConnector: TaxCodeChangeCo
     }) recover {
       case exception =>
         Logger.warn(s"Failed to Match for $nino with exception:${exception.getMessage}")
-        TaxCodeMismatch(true, Seq(), Seq())
+        throw new BadRequestException(exception.getMessage)
     }
   }
 

--- a/test/uk/gov/hmrc/tai/controllers/taxCodeChange/TaxCodeChangeControllerSpec.scala
+++ b/test/uk/gov/hmrc/tai/controllers/taxCodeChange/TaxCodeChangeControllerSpec.scala
@@ -19,6 +19,8 @@ package uk.gov.hmrc.tai.controllers.taxCodeChange
 import org.joda.time.LocalDate
 import org.mockito.Matchers
 import org.mockito.Mockito.when
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
 import org.scalatest.mock.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import play.api.libs.json.{JsBoolean, Json}
@@ -26,7 +28,7 @@ import play.api.mvc.Result
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{status, _}
 import uk.gov.hmrc.domain.Generator
-import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.{BadRequestException, HeaderCarrier}
 import uk.gov.hmrc.tai.config.FeatureTogglesConfig
 import uk.gov.hmrc.tai.mocks.MockAuthenticationPredicate
 import uk.gov.hmrc.tai.model.{TaxCodeMismatch, api}
@@ -172,6 +174,17 @@ class TaxCodeChangeControllerSpec extends PlaySpec with MockitoSugar with MockAu
         val result = controller.taxCodeMismatch(nino)(FakeRequest())
 
         contentAsJson(result) mustEqual expectedResponse
+      }
+    }
+
+    "return a BadRequest 400" when {
+      "a bad request exception has occurred" in {
+        when(taxCodeService.taxCodeMismatch(Matchers.any())(Matchers.any())).thenReturn(Future.failed(new BadRequestException("Error")))
+
+        val result = controller.taxCodeMismatch(nino)(FakeRequest())
+
+        status(result) mustEqual 400
+        contentAsString(result) mustEqual """{"reason":"Error"}"""
       }
     }
 


### PR DESCRIPTION
- [x] Unit tests passing
- [x] Coverage reached
- [x] Acceptance tests passing
- [ ] Reviewed
