### PR TITLE
leapYearFixPt2: Changed how mid point of tax year is calculated in tests

### DIFF
--- a/test/uk/gov/hmrc/tai/calculators/EstimatedPayCalculatorSpec.scala
+++ b/test/uk/gov/hmrc/tai/calculators/EstimatedPayCalculatorSpec.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.tai.calculators
 
+import org.joda.time.{Days, LocalDate}
 import org.scalatestplus.play.PlaySpec
 import uk.gov.hmrc.tai.model.PayDetails
 import uk.gov.hmrc.tai.model.enums.PayFreq
@@ -95,7 +96,11 @@ class EstimatedPayCalculatorSpec extends PlaySpec {
     "calculate net and gross pay amounts which are apportioned for the current year" when {
 
       "an employment start date is supplied which falls in the current tax year" in {
-        val startDateHalfThroughYear = TaxYear().end.minusDays(182)
+
+        val daysInHalfYear : Int = Days.daysBetween(TaxYear().start, TaxYear().next.start).getDays() /2
+
+        val startDateHalfThroughYear = TaxYear().end.minusDays(daysInHalfYear)
+
         val payDetails = PayDetails(paymentFrequency = PayFreq.weekly, pay = Some(100),
           taxablePay = Some(80), bonus = None, startDate = Some(startDateHalfThroughYear))
 

--- a/test/uk/gov/hmrc/tai/service/AutoUpdatePayServiceSpec.scala
+++ b/test/uk/gov/hmrc/tai/service/AutoUpdatePayServiceSpec.scala
@@ -2608,12 +2608,6 @@ class AutoUpdatePayServiceSpec extends PlaySpec with MockitoSugar {
     else
       Some(200625)
 
-  val midPointofTaxYearPlusOneDay = if (new LocalDate(TaxYear().year + 1,1,1).year().isLeap) {
-    new LocalDate(CurrentYear, 10, 7)
-  } else {
-    new LocalDate(CurrentYear, 10, 6)
-  }
-
   val daysInHalfYear : Int = Days.daysBetween(TaxYear().start, TaxYear().next.start).getDays() /2
 
   val midPointofTaxYearPlusOneDay: LocalDate = TaxYear().start.plusDays(daysInHalfYear+1)

--- a/test/uk/gov/hmrc/tai/service/AutoUpdatePayServiceSpec.scala
+++ b/test/uk/gov/hmrc/tai/service/AutoUpdatePayServiceSpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.tai.service
 
 
-import org.joda.time.LocalDate
+import org.joda.time.{Days, LocalDate}
 import org.mockito.ArgumentCaptor
 import org.mockito.Matchers._
 import org.mockito.Mockito.{never, times, verify, when}
@@ -1609,7 +1609,7 @@ class AutoUpdatePayServiceSpec extends PlaySpec with MockitoSugar {
 
         val sut = createSUT(mockNpsConnector, mockDesConnector, mockFeatureTogglesConfig, mockNpsConfig, mockIncomeHelper)
 
-        val payment = RtiPayment(PayFrequency.Monthly, new LocalDate(CurrentYear, 10, 6), new LocalDate(CurrentYear, 4, 20),
+        val payment = RtiPayment(PayFrequency.Monthly, midPointofTaxYearPlusOneDay, new LocalDate(CurrentYear, 4, 20),
           BigDecimal(20), BigDecimal(3000), BigDecimal(0), BigDecimal(0), None, isOccupationalPension = false, None, None, None)
 
         sut.getRemainingBiAnnual(payment) mustBe 0
@@ -2608,6 +2608,15 @@ class AutoUpdatePayServiceSpec extends PlaySpec with MockitoSugar {
     else
       Some(200625)
 
+  val midPointofTaxYearPlusOneDay = if (new LocalDate(TaxYear().year + 1,1,1).year().isLeap) {
+    new LocalDate(CurrentYear, 10, 7)
+  } else {
+    new LocalDate(CurrentYear, 10, 6)
+  }
+
+  val daysInHalfYear : Int = Days.daysBetween(TaxYear().start, TaxYear().next.start).getDays() /2
+
+  val midPointofTaxYearPlusOneDay: LocalDate = TaxYear().start.plusDays(daysInHalfYear+1)
 
   private val npsUpdateAmount = IabdUpdateAmount(
     employmentSequenceNumber = 1,


### PR DESCRIPTION
- [x] Unit tests passing
- [x] Coverage reached
- [x] Acceptance tests passing
- [ ] Reviewed
