### PR TITLE
Return a 404 when there is a NotFoundException for taxComponents API

### DIFF
--- a/app/uk/gov/hmrc/tai/controllers/CodingComponentController.scala
+++ b/app/uk/gov/hmrc/tai/controllers/CodingComponentController.scala
@@ -22,7 +22,7 @@ import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json.{Json, Writes}
 import play.api.mvc.{Action, AnyContent}
 import uk.gov.hmrc.domain.Nino
-import uk.gov.hmrc.http.BadRequestException
+import uk.gov.hmrc.http.{BadRequestException, NotFoundException}
 import uk.gov.hmrc.play.bootstrap.controller.BaseController
 import uk.gov.hmrc.tai.controllers.predicates.AuthenticationPredicate
 import uk.gov.hmrc.tai.model.api.{ApiFormats, ApiResponse}
@@ -46,6 +46,9 @@ class CodingComponentController @Inject()(authentication: AuthenticationPredicat
         case e: BadRequestException ⇒
           Logger.warn(s"BadRequestException on codingComponentsForYear: ${e.getMessage}")
           BadRequest(Json.toJson(Map("reason" → e.getMessage)))
+        case e: NotFoundException =>
+          Logger.warn(s"NotFoundException on codingComponentsForYear: ${e.getMessage}")
+          NotFound(Json.toJson(Map("reason" -> e.getMessage)))
         case e: Throwable ⇒
           throw e
       }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#  http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
- [x] Unit tests passing
- [x] Coverage reached
- [x] Acceptance tests passing
- [ ] Reviewed
