### PR TITLE
lazy the cacheRepository to prevent TAI tests requiring mongo

### DIFF
--- a/app/uk/gov/hmrc/tai/connectors/CacheConnector.scala
+++ b/app/uk/gov/hmrc/tai/connectors/CacheConnector.scala
@@ -41,7 +41,7 @@ class CacheConnector @Inject()(mongoConfig: MongoConfig) extends MongoDbConnecti
   private val expireAfter: Long = defaultExpireAfter
   private val defaultKey = "TAI-DATA"
 
-  val cacheRepository: CacheRepository = CacheRepository("TAI", expireAfter, Cache.mongoFormats)
+  lazy val cacheRepository: CacheRepository = CacheRepository("TAI", expireAfter, Cache.mongoFormats)
 
   def createOrUpdate[T](id: String, data: T, key: String = defaultKey)(implicit writes: Writes[T]): Future[T] = {
     val jsonData = if(mongoConfig.mongoEncryptionEnabled){

--- a/test/uk/gov/hmrc/tai/connectors/CacheConnectorSpec.scala
+++ b/test/uk/gov/hmrc/tai/connectors/CacheConnectorSpec.scala
@@ -495,6 +495,6 @@ class CacheConnectorSpec extends PlaySpec with MockitoSugar with FakeTaiPlayAppl
   private val atMost = 5 seconds
 
   private def createSUT(mongoConfig: MongoConfig = mock[MongoConfig], metrics: Metrics = mock[Metrics]) = new CacheConnector(mongoConfig) {
-    override val cacheRepository: CacheRepository = mock[CacheRepository]
+    override lazy val cacheRepository: CacheRepository = mock[CacheRepository]
   }
 }


### PR DESCRIPTION
- [x] Unit tests passing
- [x] Coverage reached
- [ ] Acceptance tests passing
- [ ] Reviewed
