### PR TITLE
Stop throwing when we can't find a taxCodeMisMatch 

### DIFF
--- a/app/uk/gov/hmrc/tai/controllers/taxCodeChange/TaxCodeChangeController.scala
+++ b/app/uk/gov/hmrc/tai/controllers/taxCodeChange/TaxCodeChangeController.scala
@@ -20,16 +20,13 @@ import com.google.inject.Inject
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent}
 import uk.gov.hmrc.domain.Nino
-import uk.gov.hmrc.http.BadRequestException
+import uk.gov.hmrc.http.{BadRequestException, NotFoundException}
 import uk.gov.hmrc.play.bootstrap.controller.BaseController
 import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
-import uk.gov.hmrc.tai.config.FeatureTogglesConfig
 import uk.gov.hmrc.tai.controllers.predicates.AuthenticationPredicate
 import uk.gov.hmrc.tai.model.api.ApiResponse
 import uk.gov.hmrc.tai.model.tai.TaxYear
 import uk.gov.hmrc.tai.service.TaxCodeChangeService
-
-import scala.concurrent.Future
 
 class TaxCodeChangeController @Inject()(authentication: AuthenticationPredicate,
                                         taxCodeChangeService: TaxCodeChangeService) extends BaseController {
@@ -55,6 +52,7 @@ class TaxCodeChangeController @Inject()(authentication: AuthenticationPredicate,
       taxCodeChangeService.taxCodeMismatch(nino).map { taxCodeMismatch =>
         Ok(Json.toJson(ApiResponse(taxCodeMismatch, Seq.empty)))
       } recover {
+        case ex: NotFoundException => NotFound(Json.toJson(Map("reason" -> ex.getMessage)))
         case ex: BadRequestException => BadRequest(Json.toJson(Map("reason" -> ex.getMessage)))
       }
   }


### PR DESCRIPTION
- [x] Unit tests passing
- [x] Coverage reached
- [x] Acceptance tests passing
- [ ] Reviewed
