### PR TITLE
Revert "lazy the cacheRepository to prevent TAI tests requiring mongo"

### DIFF
--- a/app/uk/gov/hmrc/tai/connectors/CacheConnector.scala
+++ b/app/uk/gov/hmrc/tai/connectors/CacheConnector.scala
@@ -41,7 +41,7 @@ class CacheConnector @Inject()(mongoConfig: MongoConfig) extends MongoDbConnecti
   private val expireAfter: Long = defaultExpireAfter
   private val defaultKey = "TAI-DATA"
 
-  lazy val cacheRepository: CacheRepository = CacheRepository("TAI", expireAfter, Cache.mongoFormats)
+  val cacheRepository: CacheRepository = CacheRepository("TAI", expireAfter, Cache.mongoFormats)
 
   def createOrUpdate[T](id: String, data: T, key: String = defaultKey)(implicit writes: Writes[T]): Future[T] = {
     val jsonData = if(mongoConfig.mongoEncryptionEnabled){

--- a/test/uk/gov/hmrc/tai/connectors/CacheConnectorSpec.scala
+++ b/test/uk/gov/hmrc/tai/connectors/CacheConnectorSpec.scala
@@ -495,6 +495,6 @@ class CacheConnectorSpec extends PlaySpec with MockitoSugar with FakeTaiPlayAppl
   private val atMost = 5 seconds
 
   private def createSUT(mongoConfig: MongoConfig = mock[MongoConfig], metrics: Metrics = mock[Metrics]) = new CacheConnector(mongoConfig) {
-    override lazy val cacheRepository: CacheRepository = mock[CacheRepository]
+    override val cacheRepository: CacheRepository = mock[CacheRepository]
   }
 }


### PR DESCRIPTION
Reverts hmrc/tai#145